### PR TITLE
Give the codecs a name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ And the server side of the above:
 func main() {
 	server, _ := execrpc.NewServer(
 		execrpc.ServerOptions[model.ExampleRequest, model.ExampleResponse]{
-			Codec: codecs.JSONCodec[model.ExampleResponse, model.ExampleRequest]{},
 			Call: func(d execrpc.Dispatcher, req model.ExampleRequest) model.ExampleResponse {
 				return model.ExampleResponse{
 					Hello: "Hello " + req.Text + "!",

--- a/client_test.go
+++ b/client_test.go
@@ -86,17 +86,17 @@ func TestExecTyped(t *testing.T) {
 	}
 
 	c.Run("JSON", func(c *qt.C) {
-		client := newClient(c, codecs.JSONCodec[model.ExampleRequest, model.ExampleResponse]{}, "EXECRPC_CODEC=json")
+		client := newClient(c, codecs.JSONCodec[model.ExampleRequest, model.ExampleResponse]{})
 		runBasicTestForClient(c, client)
 	})
 
 	c.Run("TOML", func(c *qt.C) {
-		client := newClient(c, codecs.TOMLCodec[model.ExampleRequest, model.ExampleResponse]{}, "EXECRPC_CODEC=toml")
+		client := newClient(c, codecs.TOMLCodec[model.ExampleRequest, model.ExampleResponse]{})
 		runBasicTestForClient(c, client)
 	})
 
 	c.Run("Gob", func(c *qt.C) {
-		client := newClient(c, codecs.GobCodec[model.ExampleRequest, model.ExampleResponse]{}, "EXECRPC_CODEC=gob")
+		client := newClient(c, codecs.GobCodec[model.ExampleRequest, model.ExampleResponse]{})
 		runBasicTestForClient(c, client)
 	})
 
@@ -109,7 +109,7 @@ func TestExecTyped(t *testing.T) {
 					Version: 1,
 					Cmd:     "go",
 					Args:    []string{"run", "./examples/servers/typed"},
-					Env:     []string{"EXECRPC_CODEC=json", "EXECRPC_SEND_TWO_LOG_MESSAGES=true"},
+					Env:     []string{"EXECRPC_SEND_TWO_LOG_MESSAGES=true"},
 					Timeout: 4 * time.Second,
 					OnMessage: func(msg execrpc.Message) {
 						logMessages = append(logMessages, msg)
@@ -128,7 +128,7 @@ func TestExecTyped(t *testing.T) {
 	})
 
 	c.Run("Error", func(c *qt.C) {
-		client := newClient(c, codecs.JSONCodec[model.ExampleRequest, model.ExampleResponse]{}, "EXECRPC_CODEC=json", "EXECRPC_CALL_SHOULD_FAIL=true")
+		client := newClient(c, codecs.JSONCodec[model.ExampleRequest, model.ExampleResponse]{}, "EXECRPC_CALL_SHOULD_FAIL=true")
 		result, err := client.Execute(model.ExampleRequest{Text: "hello"})
 		c.Assert(err, qt.IsNil)
 		c.Assert(result.Err(), qt.IsNotNil)
@@ -160,7 +160,7 @@ func TestExecTyped(t *testing.T) {
 }
 
 func TestExecTypedConcurrent(t *testing.T) {
-	client := newTestClient(t, codecs.JSONCodec[model.ExampleRequest, model.ExampleResponse]{}, "EXECRPC_CODEC=json")
+	client := newTestClient(t, codecs.JSONCodec[model.ExampleRequest, model.ExampleResponse]{})
 	var g errgroup.Group
 
 	for i := 0; i < 100; i++ {
@@ -195,7 +195,7 @@ func BenchmarkClient(b *testing.B) {
 	const word = "World"
 
 	b.Run("JSON", func(b *testing.B) {
-		client := newTestClient(b, codecs.JSONCodec[model.ExampleRequest, model.ExampleResponse]{}, "EXECRPC_CODEC=json")
+		client := newTestClient(b, codecs.JSONCodec[model.ExampleRequest, model.ExampleResponse]{})
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				_, err := client.Execute(model.ExampleRequest{Text: word})
@@ -207,7 +207,7 @@ func BenchmarkClient(b *testing.B) {
 	})
 
 	b.Run("TOML", func(b *testing.B) {
-		client := newTestClient(b, codecs.TOMLCodec[model.ExampleRequest, model.ExampleResponse]{}, "EXECRPC_CODEC=toml")
+		client := newTestClient(b, codecs.TOMLCodec[model.ExampleRequest, model.ExampleResponse]{})
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				_, err := client.Execute(model.ExampleRequest{Text: word})
@@ -219,7 +219,7 @@ func BenchmarkClient(b *testing.B) {
 	})
 
 	b.Run("Gob", func(b *testing.B) {
-		client := newTestClient(b, codecs.GobCodec[model.ExampleRequest, model.ExampleResponse]{}, "EXECRPC_CODEC=gob")
+		client := newTestClient(b, codecs.GobCodec[model.ExampleRequest, model.ExampleResponse]{})
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				_, err := client.Execute(model.ExampleRequest{Text: word})

--- a/codecs/codecs.go
+++ b/codecs/codecs.go
@@ -4,14 +4,34 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"errors"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
 
-// Codec defines the interface for a two way conversion between Q  and R.
+// Codec defines the interface for a two way conversion between Q and R.
 type Codec[Q, R any] interface {
 	Encode(Q) ([]byte, error)
 	Decode([]byte, *R) error
+	Name() string
+}
+
+// ErrUnknownCodec is returned when no codec is found for the given name.
+var ErrUnknownCodec = errors.New("unknown codec")
+
+// ForName returns the codec for the given name or ErrUnknownCodec if no codec is found.
+func ForName[Q, R any](name string) (Codec[Q, R], error) {
+	switch strings.ToLower(name) {
+	case "toml":
+		return TOMLCodec[Q, R]{}, nil
+	case "json":
+		return JSONCodec[Q, R]{}, nil
+	case "gob":
+		return GobCodec[Q, R]{}, nil
+	default:
+		return nil, ErrUnknownCodec
+	}
 }
 
 // TOMLCodec is a Codec that uses TOML as the underlying format.
@@ -30,6 +50,10 @@ func (c TOMLCodec[Q, R]) Encode(q Q) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
+func (c TOMLCodec[Q, R]) Name() string {
+	return "TOML"
+}
+
 // JSONCodec is a Codec that uses JSON as the underlying format.
 type JSONCodec[Q, R any] struct{}
 
@@ -39,6 +63,10 @@ func (c JSONCodec[Q, R]) Decode(b []byte, r *R) error {
 
 func (c JSONCodec[Q, R]) Encode(q Q) ([]byte, error) {
 	return json.Marshal(q)
+}
+
+func (c JSONCodec[Q, R]) Name() string {
+	return "JSON"
 }
 
 // GobCodec is a Codec that uses gob as the underlying format.
@@ -57,4 +85,8 @@ func (c GobCodec[Q, R]) Encode(q Q) ([]byte, error) {
 		return nil, err
 	}
 	return b.Bytes(), nil
+}
+
+func (c GobCodec[Q, R]) Name() string {
+	return "Gob"
 }

--- a/examples/model/model.go
+++ b/examples/model/model.go
@@ -1,14 +1,17 @@
 package model
 
+// ExampleRequest is just a simple example request.
 type ExampleRequest struct {
 	Text string `json:"text"`
 }
 
+// ExampleResponse is just a simple example response.
 type ExampleResponse struct {
 	Hello string `json:"hello"`
 	Error *Error `json:"err"`
 }
 
+// Err is just a simple example error.
 func (r ExampleResponse) Err() error {
 	if r.Error == nil {
 		// Make sure that resp.Err() == nil.
@@ -17,6 +20,7 @@ func (r ExampleResponse) Err() error {
 	return r.Error
 }
 
+// Error holds an error message.
 type Error struct {
 	Msg string `json:"msg"`
 }

--- a/examples/servers/typed/main.go
+++ b/examples/servers/typed/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/bep/execrpc"
-	"github.com/bep/execrpc/codecs"
 	"github.com/bep/execrpc/examples/model"
 )
 
@@ -16,7 +15,6 @@ func main() {
 
 	// Some test flags from the client.
 	var (
-		codecID                  = os.Getenv("EXECRPC_CODEC")
 		printOutsideServerBefore = os.Getenv("EXECRPC_PRINT_OUTSIDE_SERVER_BEFORE") != ""
 		printOutsideServerAfter  = os.Getenv("EXECRPC_PRINT_OUTSIDE_SERVER_AFTER") != ""
 		printInsideServer        = os.Getenv("EXECRPC_PRINT_INSIDE_SERVER") != ""
@@ -24,23 +22,12 @@ func main() {
 		sendLogMessage           = os.Getenv("EXECRPC_SEND_TWO_LOG_MESSAGES") != ""
 	)
 
-	var codec codecs.Codec[model.ExampleResponse, model.ExampleRequest]
-	switch codecID {
-	case "toml":
-		codec = codecs.TOMLCodec[model.ExampleResponse, model.ExampleRequest]{}
-	case "gob":
-		codec = codecs.GobCodec[model.ExampleResponse, model.ExampleRequest]{}
-	default:
-		codec = codecs.JSONCodec[model.ExampleResponse, model.ExampleRequest]{}
-	}
-
 	if printOutsideServerBefore {
 		fmt.Println("Printing outside server before")
 	}
 
 	server, err := execrpc.NewServer(
 		execrpc.ServerOptions[model.ExampleRequest, model.ExampleResponse]{
-			Codec: codec,
 			Call: func(d execrpc.Dispatcher, req model.ExampleRequest) model.ExampleResponse {
 				if printInsideServer {
 					fmt.Println("Printing inside server")

--- a/message.go
+++ b/message.go
@@ -29,6 +29,8 @@ func (m *Message) Write(w io.Writer) error {
 	return err
 }
 
+// Header is the header of a message.
+// ID and Size are set by the system.
 type Header struct {
 	ID      uint32
 	Version uint8
@@ -36,6 +38,7 @@ type Header struct {
 	Size    uint32
 }
 
+// Read reads the header from the reader.
 func (h *Header) Read(r io.Reader) error {
 	buf := make([]byte, 10)
 	_, err := io.ReadFull(r, buf)
@@ -49,6 +52,7 @@ func (h *Header) Read(r io.Reader) error {
 	return nil
 }
 
+// Write writes the header to the writer.
 func (h Header) Write(w io.Writer) error {
 	buff := make([]byte, 10)
 	binary.BigEndian.PutUint32(buff[0:4], h.ID)


### PR DESCRIPTION
And pass that name to the server to be used if codec is not set.

This makes the simple cases more robust and smaller.
