### PR TITLE
Make Header.Version/Status uin16

### DIFF
--- a/client.go
+++ b/client.go
@@ -131,7 +131,7 @@ func StartClientRaw(opts ClientRawOptions) (*ClientRaw, error) {
 // ClientRaw is a raw RPC client.
 // Raw means that the client doesn't do any type conversion, a byte slice is what you get.
 type ClientRaw struct {
-	version uint8
+	version uint16
 
 	conn conn
 
@@ -298,7 +298,7 @@ type ClientOptions[Q, R any] struct {
 // ClientRawOptions are options for the raw part of the client.
 type ClientRawOptions struct {
 	// Version number passed to the server.
-	Version uint8
+	Version uint16
 
 	// The server to start.
 	Cmd string

--- a/client_test.go
+++ b/client_test.go
@@ -143,6 +143,9 @@ func TestExecTyped(t *testing.T) {
 		_, err = client.Execute(model.ExampleRequest{Text: "world"})
 		c.Assert(err, qt.IsNil)
 		c.Assert(len(logMessages), qt.Equals, 2)
+		c.Assert(string(logMessages[0].Body), qt.Equals, "first log message")
+		c.Assert(logMessages[0].Header.Status, qt.Equals, uint16(0))
+		c.Assert(logMessages[0].Header.Version, qt.Equals, uint16(32))
 		c.Assert(client.Close(), qt.IsNil)
 	})
 

--- a/examples/servers/typed/main.go
+++ b/examples/servers/typed/main.go
@@ -42,13 +42,15 @@ func main() {
 					d.Send(
 						execrpc.Message{
 							Header: execrpc.Header{
-								Status: 150,
+								Version: 32,
+								Status:  150,
 							},
 							Body: []byte("first log message"),
 						},
 						execrpc.Message{
 							Header: execrpc.Header{
-								Status: 150,
+								Version: 32,
+								Status:  150,
 							},
 							Body: []byte("second log message"),
 						})

--- a/message.go
+++ b/message.go
@@ -33,31 +33,33 @@ func (m *Message) Write(w io.Writer) error {
 // ID and Size are set by the system.
 type Header struct {
 	ID      uint32
-	Version uint8
-	Status  uint8
+	Version uint16
+	Status  uint16
 	Size    uint32
 }
 
+const headerSize = 12
+
 // Read reads the header from the reader.
 func (h *Header) Read(r io.Reader) error {
-	buf := make([]byte, 10)
+	buf := make([]byte, headerSize)
 	_, err := io.ReadFull(r, buf)
 	if err != nil {
 		return err
 	}
 	h.ID = binary.BigEndian.Uint32(buf[0:4])
-	h.Version = buf[4]
-	h.Status = buf[5]
+	h.Version = binary.BigEndian.Uint16(buf[4:6])
+	h.Status = binary.BigEndian.Uint16(buf[6:8])
 	h.Size = binary.BigEndian.Uint32(buf[6:])
 	return nil
 }
 
 // Write writes the header to the writer.
 func (h Header) Write(w io.Writer) error {
-	buff := make([]byte, 10)
+	buff := make([]byte, headerSize)
 	binary.BigEndian.PutUint32(buff[0:4], h.ID)
-	buff[4] = h.Version
-	buff[5] = h.Status
+	binary.BigEndian.PutUint16(buff[4:6], h.Version)
+	binary.BigEndian.PutUint16(buff[6:8], h.Status)
 	binary.BigEndian.PutUint32(buff[6:], h.Size)
 	_, err := w.Write(buff)
 	return err


### PR DESCRIPTION
One bytes sounds like plenty, but it's better to get it on the safe side now, as
this will be harder
to change once people start using this in the wild.
